### PR TITLE
fix: tooltip mouse leave behaviour

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { Popover, ArrowContainer, PopoverPosition } from "react-tiny-popover";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const Tooltip = ({
   tip,
@@ -10,6 +10,7 @@ const Tooltip = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isInside, setIsInside] = useState(false);
+  const isMouseOverButton = useRef(false);
 
   const positions: PopoverPosition[] = ["top", "bottom", "left", "right"];
   return (
@@ -45,10 +46,14 @@ const Tooltip = ({
       )}
     >
       <button
-        onMouseEnter={() => setIsOpen(true)}
+        onMouseEnter={() => {
+          isMouseOverButton.current = true;
+          setIsOpen(true);
+        }}
         onMouseLeave={async () => {
+          isMouseOverButton.current = false;
           await new Promise((r) => setTimeout(r, 500));
-          if (!isInside) {
+          if (!isInside && !isMouseOverButton.current) {
             setIsOpen(false);
           }
         }}


### PR DESCRIPTION
Tooltip gets closed on mouse leave after a delay. But if the user hovers the button before delay ends it gives a weird experience.

old:
![old](https://user-images.githubusercontent.com/18082091/226913368-d2ada34f-4519-45bd-86cc-68fc51be9e30.gif)
new:
![new](https://user-images.githubusercontent.com/18082091/226913396-ec1886ae-22f6-404b-b757-382a22acaa66.gif)

Note: I had to use refs since if I use useState the callback would remember the old value of isMouseOverButton. 
Actually the `isInside` check in the button is not needed since its remembered by the callback, because of that the if `isInside` is always false inside the callback. 